### PR TITLE
Add Google and Prisma metrics exports to Graphite

### DIFF
--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -26,12 +26,12 @@ import (
 // GenerateComplianceInfo returns metrics from given compliance info
 func GenerateComplianceInfo(timeNow int64, prefix string, ci []api.ComplianceInfo) []graphite.Metric {
 	var metrics []graphite.Metric
-	for _, x := range ci {
-		metricPrefix := prefix + escapeMetricName(x.Name)
-		metrics = append(metrics, graphite.NewMetric(metricPrefix+".policies_total", strconv.Itoa(x.PoliciesCount), timeNow))
-		metrics = append(metrics, graphite.NewMetric(metricPrefix+".assets_passed", strconv.Itoa(x.PassedAssetsCount), timeNow))
-		metrics = append(metrics, graphite.NewMetric(metricPrefix+".assets_failed", strconv.Itoa(x.FailedAssetsCount), timeNow))
-		metrics = append(metrics, graphite.NewMetric(metricPrefix+".assets_total", strconv.Itoa(x.TotalAssetsCount), timeNow))
+	for _, entry := range ci {
+		metricPrefix := prefix + escapeMetricName(entry.Name)
+		metrics = append(metrics, graphite.NewMetric(metricPrefix+".policies_total", strconv.Itoa(entry.PoliciesCount), timeNow))
+		metrics = append(metrics, graphite.NewMetric(metricPrefix+".assets_passed", strconv.Itoa(entry.PassedAssetsCount), timeNow))
+		metrics = append(metrics, graphite.NewMetric(metricPrefix+".assets_failed", strconv.Itoa(entry.FailedAssetsCount), timeNow))
+		metrics = append(metrics, graphite.NewMetric(metricPrefix+".assets_total", strconv.Itoa(entry.TotalAssetsCount), timeNow))
 	}
 	return metrics
 }
@@ -39,9 +39,9 @@ func GenerateComplianceInfo(timeNow int64, prefix string, ci []api.ComplianceInf
 // GenerateSSCSourcesDelay returns metrics from given delay map
 func GenerateSSCSourcesDelay(timeNow int64, prefix string, delay map[string]time.Duration) []graphite.Metric {
 	var metrics []graphite.Metric
-	for k, v := range delay {
-		metricPrefix := prefix + escapeMetricName(k)
-		metrics = append(metrics, graphite.NewMetric(metricPrefix+".policies_total", fmt.Sprintf("%f", v.Seconds()), timeNow))
+	for name, duration := range delay {
+		metricPrefix := prefix + escapeMetricName(name)
+		metrics = append(metrics, graphite.NewMetric(metricPrefix+".policies_total", fmt.Sprintf("%f", duration.Seconds()), timeNow))
 	}
 	return metrics
 }

--- a/graphite/graphite_test.go
+++ b/graphite/graphite_test.go
@@ -16,6 +16,7 @@ package graphite
 
 import (
 	"testing"
+	"time"
 
 	"github.com/bookingcom/cloudsec-metrics/api"
 	"github.com/marpaia/graphite-golang"
@@ -39,6 +40,15 @@ func TestGraphite(t *testing.T) {
 		assert.Nil(t, g, "Test case %d nil object check failed", i)
 	}
 
-	assert.NoError(t, SendComplianceInfo(&graphite.Graphite{}, "", nil), "Empty metric send should do nothing and return no errors")
-	assert.NoError(t, SendComplianceInfo(&graphite.Graphite{}, "", []api.ComplianceInfo{{Name: "test{name}"}}), "Empty metric send should do nothing and return no errors")
+	assert.NoError(t, SendComplianceInfo(&graphite.Graphite{}, "", nil),
+		"Empty metric send should do nothing and return no errors")
+	assert.NoError(t, SendComplianceInfo(&graphite.Graphite{}, "", []api.ComplianceInfo{{Name: "test{name}"}}),
+		"Single metric send to empty Graphite should do nothing and return no errors")
+	assert.NoError(t, SendSSCSourcesDelay(&graphite.Graphite{}, "", nil),
+		"Empty metric send should do nothing and return no errors")
+	assert.NoError(t, SendSSCSourcesDelay(&graphite.Graphite{}, "", map[string]time.Duration{"test": time.Second}),
+		"Single metric send to empty Graphite should do nothing and return no errors")
+	assert.NoError(t, SendMetric(&graphite.Graphite{}, "", ""),
+		"Single metric send should do nothing and return no errors")
+	assert.Equal(t, "_test_of_metric", escapeMetricName("(test)of/metric"))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"testing"
 
+	"github.com/bookingcom/cloudsec-metrics/api"
 	"github.com/marpaia/graphite-golang"
 	"github.com/stretchr/testify/assert"
 )
@@ -58,7 +59,7 @@ func TestCollectMetrics(t *testing.T) {
 }
 
 func TestSendMetrics(t *testing.T) {
-	m := metrics{}
+	m := metrics{complianceInfo: []api.ComplianceInfo{}}
 	sendMetrics(&m, &senders{graphite: &graphite.Graphite{}}, opts{})
-	assert.Equal(t, metrics{}, m, "Metrics unchanged after send function call")
+	assert.Equal(t, metrics{complianceInfo: []api.ComplianceInfo{}}, m, "Metrics unchanged after send function call")
 }


### PR DESCRIPTION
$subj, also applied `escapeMetricName` to both metric name and user-input metric prefix to make it safer to send into Graphite.