### PR TITLE
Replace improper SCC source delay metric name

### DIFF
--- a/graphite/graphite.go
+++ b/graphite/graphite.go
@@ -41,7 +41,7 @@ func GenerateSSCSourcesDelay(timeNow int64, prefix string, delay map[string]time
 	var metrics []graphite.Metric
 	for name, duration := range delay {
 		metricPrefix := prefix + escapeMetricName(name)
-		metrics = append(metrics, graphite.NewMetric(metricPrefix+".policies_total", fmt.Sprintf("%f", duration.Seconds()), timeNow))
+		metrics = append(metrics, graphite.NewMetric(metricPrefix+".seconds", fmt.Sprintf("%f", duration.Seconds()), timeNow))
 	}
 	return metrics
 }

--- a/graphite/graphite_test.go
+++ b/graphite/graphite_test.go
@@ -42,7 +42,7 @@ func TestGraphite(t *testing.T) {
 	assert.Nil(t, GenerateSSCSourcesDelay(0, "", nil),
 		"Run with no metrics should return nil")
 	assert.Equal(t,
-		[]graphite.Metric{{Name: "test.policies_total", Value: "0.065000", Timestamp: 0}},
+		[]graphite.Metric{{Name: "test.seconds", Value: "0.065000", Timestamp: 0}},
 		GenerateSSCSourcesDelay(0, "", map[string]time.Duration{"test": time.Millisecond * 65}),
 		"Single metric send to empty Graphite should do nothing and return no errors")
 	assert.Equal(t, "_test_of_metric", escapeMetricName("(test)of/metric"))


### PR DESCRIPTION
Had the wrong name committed previously, discovered with local Grafana test.