### PR TITLE
Switch to go-prisma library

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,24 +20,11 @@ jobs:
         go-version: 1.13
 
     - name: build and test
-      run: |
-        go test -timeout=60s -covermode=count -coverprofile=$GITHUB_WORKSPACE/profile.cov ./...
+      run: go test -race -timeout=60s -covermode=atomic -coverprofile=$GITHUB_WORKSPACE/profile.cov ./...
     - name: install golangci-lint and goveralls
-      run: |
-        curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.21.0
-#        go get -u github.com/mattn/goveralls
+      run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $GITHUB_WORKSPACE v1.23.6
     - name: run linters
-      run: |
-        $GITHUB_WORKSPACE/golangci-lint run --out-format=tab --disable-all --enable=unconvert \
-          --enable=megacheck --enable=structcheck --enable=gas --enable=gocyclo --enable=dupl --enable=misspell \
-          --enable=unparam --enable=varcheck --enable=deadcode --enable=typecheck \
-          --enable=ineffassign --enable=varcheck --enable=vet --enable=vetshadow --enable=golint \
-          --enable=staticcheck --enable=goconst --enable=errcheck --enable=gosimple ./... ;
-    #    - name: submit coverage
-    #      run: |
-    #        $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/profile.cov
-    #      env:
-    #        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: $GITHUB_WORKSPACE/golangci-lint run ./... ;
 
     - name: build docker image
       run: docker-compose build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,36 @@
+linters:
+  enable:
+  - bodyclose
+  - deadcode
+  - depguard
+  - dogsled
+  - dupl
+  - errcheck
+  - gochecknoinits
+  - goconst
+  - gocritic
+  - gocyclo
+  - gofmt
+  - goimports
+  - golint
+  - goprintffuncname
+  - gochecknoglobals
+  - gochecknoinits
+  - gosec
+  - gosimple
+  - govet
+  - ineffassign
+  - interfacer
+  - misspell
+  - nakedret
+  - rowserrcheck
+  - scopelint
+  - staticcheck
+  - structcheck
+  - stylecheck
+  - typecheck
+  - unconvert
+  - unparam
+  - unused
+  - varcheck
+  - whitespace

--- a/api/prisma.go
+++ b/api/prisma.go
@@ -15,25 +15,20 @@
 package api
 
 import (
-	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
-	"log"
-	"net/http"
-	"time"
 
+	"github.com/paskal/go-prisma"
 	"github.com/pkg/errors"
 )
 
-// Prisma is an object to make API calls to Palo Alto Prisma,
-// authorized requests if proper Token is set
+// Prisma contain credentials for API access
 type Prisma struct {
-	Login          string
-	Password       string
-	Token          string `json:"token"`
-	APIUrl         string
-	tokenRenewTime time.Time
+	api apiCaller
+}
+
+type apiCaller interface {
+	DoAPIRequest(method, url string, body io.Reader) ([]byte, error)
 }
 
 // ComplianceInfo store assets compliance information for single policy
@@ -52,14 +47,17 @@ type CompliancePosture struct {
 	ComplianceDetails []ComplianceInfo `json:"complianceDetails"`
 }
 
-// prismRenewTimeout defines how often auth token is renewed,
-// after 10 minutes it gets invalidated and new complete login is required
-const prismRenewTimeout = time.Minute * 3
+// NewPrisma returns new Prisma client
+func NewPrisma(username, password, apiURL string) *Prisma {
+	p := Prisma{}
+	p.api = prisma.NewClient(username, password, apiURL)
+	return &p
+}
 
 // GatherComplianceInfo get assets compliance information for last day
 // https://api.docs.prismacloud.io/reference#compliance-posture
 func (p *Prisma) GatherComplianceInfo() ([]ComplianceInfo, error) {
-	data, err := p.doAPIRequest("GET", "/compliance/posture?timeType=to_now&timeUnit=day", nil)
+	data, err := p.api.DoAPIRequest("GET", "/compliance/posture?timeType=to_now&timeUnit=day", nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "error requesting assets information")
 	}
@@ -75,81 +73,8 @@ func (p *Prisma) GatherComplianceInfo() ([]ComplianceInfo, error) {
 // GetAPIHealthStatus gets Prisma API health information and returns 1 on healthy response, 0 otherwise
 // https://api.docs.prismacloud.io/reference#health-check
 func (p *Prisma) GetAPIHealthStatus() int {
-	if _, err := p.doAPIRequest("GET", "/check", nil); err != nil {
+	if _, err := p.api.DoAPIRequest("GET", "/check", nil); err != nil {
 		return 0
 	}
 	return 1
-}
-
-// doAPIRequest does request to API with specified method and returns response body on success
-func (p *Prisma) doAPIRequest(method, url string, body io.Reader) ([]byte, error) {
-	req, err := http.NewRequest(method, p.APIUrl+url, body)
-	if err != nil {
-		return nil, errors.Wrap(err, "error creating request")
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if time.Since(p.tokenRenewTime) > prismRenewTimeout {
-		if err := p.authenticate(); err != nil {
-			return nil, errors.Wrap(err, "error getting auth token")
-		}
-	}
-	req.Header.Set("x-redlock-auth", p.Token)
-	httpClient := http.Client{Timeout: time.Second * 5}
-	response, err := httpClient.Do(req)
-	if err != nil {
-		return nil, errors.Wrap(err, "error making request")
-	}
-	data, err := ioutil.ReadAll(response.Body)
-	defer response.Body.Close()
-	if err != nil {
-		return nil, errors.Wrapf(err, "error reading response body, response body: %q", data)
-	}
-	switch response.StatusCode {
-	case http.StatusOK:
-		return data, nil
-	case http.StatusUnauthorized:
-		return nil, errors.Errorf("authentication error on request, response body: %q", data)
-	case http.StatusBadRequest:
-		return nil, errors.Errorf("bad request parameters, check your request body, response body: %q", data)
-	case http.StatusInternalServerError:
-		return nil, errors.Errorf("server internal error during request processing, response body: %q", data)
-	default:
-		return nil, errors.Errorf("%v, response body: %q", response.Status, data)
-	}
-}
-
-// authenticate gets or renews the API authentication token
-// https://api.docs.prismacloud.io/reference#login
-func (p *Prisma) authenticate() error {
-	p.tokenRenewTime = time.Now()
-	switch p.Token {
-	case "":
-		// no token set yet, first login
-		loginData := map[string]string{"username": p.Login, "password": p.Password}
-		jsonValue, err := json.Marshal(loginData)
-		if err != nil {
-			return errors.Wrap(err, "error marshaling login data")
-		}
-		data, err := p.doAPIRequest("POST", "/login", bytes.NewBuffer(jsonValue))
-		if err != nil {
-			return errors.Wrapf(err, "error logging in with user %q", p.Login)
-		}
-		if err := json.Unmarshal(data, p); err != nil {
-			return errors.Wrap(err, "error obtaining token from login response")
-		}
-	default:
-		// token is set and we will try to renew it
-		data, err := p.doAPIRequest("GET", "/auth_token/extend", nil)
-		if err != nil {
-			log.Printf("[INFO] Error extending token, will re-login, %v", err)
-			p.Token = ""
-			return p.authenticate()
-		}
-		if err := json.Unmarshal(data, p); err != nil {
-			log.Printf("[INFO] Error obtaining token from extend token response, will re-login, %v", err)
-			p.Token = ""
-			return p.authenticate()
-		}
-	}
-	return nil
 }

--- a/api/prisma_test.go
+++ b/api/prisma_test.go
@@ -15,165 +15,17 @@
 package api
 
 import (
-	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestApiRequest(t *testing.T) {
-	// prepare servers
-	goodServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/login", r.URL.Path)
-		assert.Equal(t, "POST", r.Method)
-		buf := new(bytes.Buffer)
-		_, _ = buf.ReadFrom(r.Body)
-		assert.Equal(t, "test_text", buf.String())
-		_, _ = fmt.Fprint(w, "one, two, three")
-	}))
-	defer goodServer.Close()
-	badServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/", r.URL.Path)
-		assert.Equal(t, "GET", r.Method)
-		w.Header().Set("Content-Length", "1")
-	}))
-	defer badServer.Close()
-	serverStatusUnauthorized := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer serverStatusUnauthorized.Close()
-	serverStatusBadRequest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-	}))
-	defer serverStatusBadRequest.Close()
-	serverStatusInternalServerError := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer serverStatusInternalServerError.Close()
-	serverStatusNotFound := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer serverStatusNotFound.Close()
-
-	var testAPIRequestsDataset = []struct {
-		serverURL    string
-		method       string
-		url          string
-		error        string
-		responseBody []byte
-		body         io.Reader
-	}{
-		{serverURL: "http://[::1]:namedport", method: "POST",
-			error: "error creating request: parse http://[::1]:namedport: invalid port \":namedport\" after host"},
-		{serverURL: "nonexistent_url", method: "POST",
-			error: "error getting auth token: error logging in with user \"\": error making request: Post nonexistent_url/login: unsupported protocol scheme \"\""},
-		{serverURL: goodServer.URL, method: "POST", url: "/login",
-			responseBody: []byte("one, two, three"), body: bytes.NewReader([]byte("test_text"))},
-		{serverURL: badServer.URL, method: "GET", url: "/",
-			error: "error reading response body, response body: \"\": unexpected EOF"},
-		{serverURL: serverStatusUnauthorized.URL, method: "GET",
-			error: "authentication error on request, response body: \"\""},
-		{serverURL: serverStatusBadRequest.URL, method: "GET",
-			error: "bad request parameters, check your request body, response body: \"\""},
-		{serverURL: serverStatusInternalServerError.URL, method: "GET",
-			error: "server internal error during request processing, response body: \"\""},
-		{serverURL: serverStatusNotFound.URL, method: "GET",
-			error: "404 Not Found, response body: \"\""},
-	}
-
-	// start tests
-	p := &Prisma{}
-
-	for i, x := range testAPIRequestsDataset {
-		p.APIUrl = x.serverURL
-		data, err := p.doAPIRequest(x.method, x.url, x.body)
-		if x.error != "" {
-			assert.EqualError(t, err, x.error, "Test case %d error check failed", i)
-		} else {
-			assert.NoError(t, err, "Test case %d error check failed", i)
-		}
-		if x.responseBody != nil {
-			assert.Equal(t, x.responseBody, data, "Test case %d response data check failed", i)
-		} else {
-			assert.Nil(t, data, "Test case %d response data check failed", i)
-		}
-	}
-}
-
-func TestNewPrisma(t *testing.T) {
-	// prepare servers
-	goodServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/login", r.URL.Path)
-		assert.Equal(t, "POST", r.Method)
-		buf := new(bytes.Buffer)
-		_, _ = buf.ReadFrom(r.Body)
-		assert.Equal(t, "{\"password\":\"test_password\",\"username\":\"test_user\"}", buf.String())
-		_, _ = fmt.Fprint(w, "{\"token\":\"test_token\"}")
-	}))
-	defer goodServer.Close()
-	goodRenewServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/auth_token/extend", r.URL.Path)
-		assert.Equal(t, "GET", r.Method)
-		_, _ = fmt.Fprint(w, "{\"token\":\"test_token_renewed\"}")
-	}))
-	defer goodRenewServer.Close()
-	badRenewServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer badRenewServer.Close()
-	badEmptyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	}))
-	defer badEmptyServer.Close()
-	badAnswerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, r.URL.Path, "/login")
-		assert.Equal(t, "POST", r.Method)
-		buf := new(bytes.Buffer)
-		_, _ = buf.ReadFrom(r.Body)
-		assert.Equal(t, "{\"password\":\"\",\"username\":\"\"}", buf.String())
-		_, _ = fmt.Fprint(w, "not_json")
-	}))
-	defer badAnswerServer.Close()
-
-	var testAPIRequestsDataset = []struct {
-		serverURL     string
-		username      string
-		password      string
-		error         string
-		responseToken string
-		setToken      string
-	}{
-		{serverURL: "nonexistent_url", username: "test_username",
-			error: "error logging in with user \"test_username\": error making request: Post nonexistent_url/login: unsupported protocol scheme \"\""},
-		{serverURL: goodServer.URL, username: "test_user", password: "test_password", responseToken: "test_token"},
-		{serverURL: badAnswerServer.URL,
-			error: "error obtaining token from login response: invalid character 'o' in literal null (expecting 'u')"},
-		{serverURL: goodRenewServer.URL, username: "test_user", password: "test_password",
-			setToken: "old_good_token", responseToken: "test_token_renewed"},
-		{serverURL: badRenewServer.URL, username: "test_user", password: "test_password", setToken: "old_bad_token",
-			error: "error logging in with user \"test_user\": authentication error on request, response body: \"\""},
-		{serverURL: badEmptyServer.URL, username: "test_user", password: "test_password", setToken: "old_bad_token",
-			error: "error obtaining token from login response: unexpected end of JSON input"},
-	}
-
-	// start tests
-
-	for i, x := range testAPIRequestsDataset {
-		p := &Prisma{Login: x.username, Password: x.password, APIUrl: x.serverURL}
-		p.Token = x.setToken
-		err := p.authenticate()
-		if x.error != "" {
-			assert.EqualError(t, err, x.error, "Test case %d error check failed", i)
-		} else {
-			assert.NoError(t, err, "Test case %d error check failed", i)
-		}
-		assert.NotNil(t, p, "Test case %d Prisma object return check failed", i)
-		assert.Equal(t, x.responseToken, p.Token, "Test case %d Prisma object token check failed", i)
-	}
-}
 
 func TestPrisma_GatherComplianceInfo(t *testing.T) {
 	// prepare servers
@@ -196,7 +48,7 @@ func TestPrisma_GatherComplianceInfo(t *testing.T) {
 		asset     []ComplianceInfo
 	}{
 		{serverURL: "nonexistent_url",
-			error: "error requesting assets information: error getting auth token: error logging in with user \"\": error making request: Post nonexistent_url/login: unsupported protocol scheme \"\""},
+			error: "error requesting assets information: error making request: Get nonexistent_url/compliance/posture?timeType=to_now&timeUnit=day: unsupported protocol scheme \"\""},
 		{serverURL: goodServer.URL,
 			asset: []ComplianceInfo{{"test_name", "test description", 66, 69, 99, 69 + 99}}},
 		{serverURL: badAnswerServer.URL,
@@ -207,7 +59,7 @@ func TestPrisma_GatherComplianceInfo(t *testing.T) {
 	p := &Prisma{}
 
 	for i, x := range testAPIRequestsDataset {
-		p.APIUrl = x.serverURL
+		p.api = &mockClient{APIURL: x.serverURL}
 		assetInfo, err := p.GatherComplianceInfo()
 		if x.error != "" {
 			assert.EqualError(t, err, x.error, "Test case %d error check failed", i)
@@ -243,8 +95,28 @@ func TestPrisma_GetAPIHealthStatus(t *testing.T) {
 	p := &Prisma{}
 
 	for i, x := range testAPIRequestsDataset {
-		p.APIUrl = x.serverURL
+		p.api = &mockClient{APIURL: x.serverURL}
 		status := p.GetAPIHealthStatus()
 		assert.Equal(t, x.status, status, "Test case %d status code check failed", i)
+	}
+}
+
+type mockClient struct{ APIURL string }
+
+func (m *mockClient) DoAPIRequest(method, url string, body io.Reader) ([]byte, error) {
+	req, _ := http.NewRequest(method, m.APIURL+url, body)
+	req.Header.Set("Content-Type", "application/json")
+	httpClient := http.Client{Timeout: time.Second}
+	response, err := httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "error making request")
+	}
+	data, _ := ioutil.ReadAll(response.Body)
+	_ = response.Body.Close()
+	switch response.StatusCode {
+	case http.StatusInternalServerError:
+		return nil, errors.Errorf("server internal error during request processing, response body: %q", data)
+	default:
+		return data, nil
 	}
 }

--- a/api/prisma_test.go
+++ b/api/prisma_test.go
@@ -15,43 +15,25 @@
 package api
 
 import (
-	"fmt"
 	"io"
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPrisma_GatherComplianceInfo(t *testing.T) {
-	// prepare servers
-	goodServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/compliance/posture", r.URL.Path)
-		assert.Equal(t, "GET", r.Method)
-		_, _ = fmt.Fprint(w, `{"timestamp": 1571919534777,"complianceDetails":[{"name":"test_name","description":"test description","passedResources":69,"assignedPolicies":66,"failedResources":99, "totalResources":168}]}`)
-	}))
-	defer goodServer.Close()
-	badAnswerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/compliance/posture", r.URL.Path)
-		assert.Equal(t, "GET", r.Method)
-		_, _ = fmt.Fprint(w, "not_json")
-	}))
-	defer badAnswerServer.Close()
-
 	var testAPIRequestsDataset = []struct {
-		serverURL string
+		serverErr string
 		error     string
+		answer    []byte
 		asset     []ComplianceInfo
 	}{
-		{serverURL: "nonexistent_url",
-			error: "error requesting assets information: error making request: Get nonexistent_url/compliance/posture?timeType=to_now&timeUnit=day: unsupported protocol scheme \"\""},
-		{serverURL: goodServer.URL,
+		{serverErr: "mock error",
+			error: "error requesting assets information: mock error"},
+		{answer: []byte(`{"timestamp": 1571919534777,"complianceDetails":[{"name":"test_name","description":"test description","passedResources":69,"assignedPolicies":66,"failedResources":99, "totalResources":168}]}`),
 			asset: []ComplianceInfo{{"test_name", "test description", 66, 69, 99, 69 + 99}}},
-		{serverURL: badAnswerServer.URL,
+		{answer: []byte("not_json"),
 			error: "error unmarshaling assets information: invalid character 'o' in literal null (expecting 'u')"},
 	}
 
@@ -59,7 +41,8 @@ func TestPrisma_GatherComplianceInfo(t *testing.T) {
 	p := &Prisma{}
 
 	for i, x := range testAPIRequestsDataset {
-		p.api = &mockClient{APIURL: x.serverURL}
+		p.api = &mockClient{t: t, url: "/compliance/posture?timeType=to_now&timeUnit=day", method: "GET",
+			err: x.serverErr, answer: x.answer}
 		assetInfo, err := p.GatherComplianceInfo()
 		if x.error != "" {
 			assert.EqualError(t, err, x.error, "Test case %d error check failed", i)
@@ -71,52 +54,37 @@ func TestPrisma_GatherComplianceInfo(t *testing.T) {
 }
 
 func TestPrisma_GetAPIHealthStatus(t *testing.T) {
-	// prepare servers
-	goodServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/check", r.URL.Path)
-		assert.Equal(t, "GET", r.Method)
-	}))
-	defer goodServer.Close()
-	badAnswerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer badAnswerServer.Close()
-
 	var testAPIRequestsDataset = []struct {
-		serverURL string
-		status    int
+		err    string
+		status int
 	}{
-		{serverURL: "nonexistent_url"},
-		{serverURL: goodServer.URL, status: 1},
-		{serverURL: badAnswerServer.URL},
+		{err: "mock problem"},
+		{status: 1},
 	}
 
 	// start tests
 	p := &Prisma{}
 
 	for i, x := range testAPIRequestsDataset {
-		p.api = &mockClient{APIURL: x.serverURL}
+		p.api = &mockClient{t: t, url: "/check", method: "GET", err: x.err}
 		status := p.GetAPIHealthStatus()
 		assert.Equal(t, x.status, status, "Test case %d status code check failed", i)
 	}
 }
 
-type mockClient struct{ APIURL string }
+type mockClient struct {
+	t      *testing.T
+	method string
+	url    string
+	answer []byte
+	err    string
+}
 
-func (m *mockClient) DoAPIRequest(method, url string, body io.Reader) ([]byte, error) {
-	req, _ := http.NewRequest(method, m.APIURL+url, body)
-	req.Header.Set("Content-Type", "application/json")
-	httpClient := http.Client{Timeout: time.Second}
-	response, err := httpClient.Do(req)
-	if err != nil {
-		return nil, errors.Wrap(err, "error making request")
+func (m *mockClient) DoAPIRequest(method, url string, _ io.Reader) ([]byte, error) {
+	assert.Equal(m.t, m.url, url)
+	assert.Equal(m.t, m.method, method)
+	if m.err != "" {
+		return nil, errors.New(m.err)
 	}
-	data, _ := ioutil.ReadAll(response.Body)
-	_ = response.Body.Close()
-	switch response.StatusCode {
-	case http.StatusInternalServerError:
-		return nil, errors.Errorf("server internal error during request processing, response body: %q", data)
-	default:
-		return data, nil
-	}
+	return m.answer, nil
 }

--- a/api/prisma_test.go
+++ b/api/prisma_test.go
@@ -24,12 +24,12 @@ import (
 
 func TestPrisma_GatherComplianceInfo(t *testing.T) {
 	var testAPIRequestsDataset = []struct {
-		serverErr string
+		serverErr error
 		error     string
 		answer    []byte
 		asset     []ComplianceInfo
 	}{
-		{serverErr: "mock error",
+		{serverErr: errors.New("mock error"),
 			error: "error requesting assets information: mock error"},
 		{answer: []byte(`{"timestamp": 1571919534777,"complianceDetails":[{"name":"test_name","description":"test description","passedResources":69,"assignedPolicies":66,"failedResources":99, "totalResources":168}]}`),
 			asset: []ComplianceInfo{{"test_name", "test description", 66, 69, 99, 69 + 99}}},
@@ -55,10 +55,10 @@ func TestPrisma_GatherComplianceInfo(t *testing.T) {
 
 func TestPrisma_GetAPIHealthStatus(t *testing.T) {
 	var testAPIRequestsDataset = []struct {
-		err    string
+		err    error
 		status int
 	}{
-		{err: "mock problem"},
+		{err: errors.New("mock problem")},
 		{status: 1},
 	}
 
@@ -77,14 +77,11 @@ type mockClient struct {
 	method string
 	url    string
 	answer []byte
-	err    string
+	err    error
 }
 
 func (m *mockClient) DoAPIRequest(method, url string, _ io.Reader) ([]byte, error) {
 	assert.Equal(m.t, m.url, url)
 	assert.Equal(m.t, m.method, method)
-	if m.err != "" {
-		return nil, errors.New(m.err)
-	}
-	return m.answer, nil
+	return m.answer, m.err
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,8 @@ require (
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jtaczanowski/go-graphite-client v1.0.0
-	github.com/pkg/errors v0.8.1
+	github.com/paskal/go-prisma v0.0.4
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0
 	go.opencensus.io v0.22.1 // indirect
 	golang.org/x/net v0.0.0-20190916140828-c8589233b77d // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,10 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/paskal/go-prisma v0.0.4 h1:F3j0AuXe417aEJ1tQjeClQaniLqAGa+XX0WGUIS5tJk=
+github.com/paskal/go-prisma v0.0.4/go.mod h1:RI62w19oSb/ymDlwXYBsofjZgieLa1sFkIqavMGlqDU=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func prepareCollectors(opts opts) (*collectors, error) {
 	var collectors = &collectors{}
 	if opts.PrismAPIKey != "" && opts.PrismAPIPassword != "" {
 		log.Printf("[INFO] Initialising Prisma data collection with API key %s", opts.PrismAPIKey)
-		collectors.prisma = &api.Prisma{Login: opts.PrismAPIKey, Password: opts.PrismAPIPassword, APIUrl: opts.PrismAPIUrl}
+		collectors.prisma = api.NewPrisma(opts.PrismAPIKey, opts.PrismAPIPassword, opts.PrismAPIUrl)
 	}
 	if opts.SCCOrgID != "" {
 		var err error

--- a/main_test.go
+++ b/main_test.go
@@ -30,8 +30,7 @@ func TestPrepareCollectors(t *testing.T) {
 		collectors *collectors
 	}{
 		{collectors: &collectors{}},
-		{collectors: &collectors{
-			prisma: &api.Prisma{Login: "bad", Password: "bad_pass", APIUrl: "bad_host"}},
+		{collectors: &collectors{prisma: api.NewPrisma("bad", "bad_pass", "bad_host")},
 			opts: opts{PrismAPIKey: "bad", PrismAPIPassword: "bad_pass", PrismAPIUrl: "bad_host"}},
 		{opts: opts{SCCOrgID: "bad"}, err: true},
 	}


### PR DESCRIPTION
Switching to go-prisma removes a lot of code from this project.

Also, this PR moves golangci-lint configuration to ` .golangci.yml`.